### PR TITLE
Add toml as dependency for pyproject.toml checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "homepage"="https://github.com/AlexanderMelde/yapf-action"
 LABEL "maintainer"="Alexander Melde <alexander@melde.net>"
 
 RUN pip install --upgrade pip
-RUN pip install yapf
+RUN pip install yapf toml
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This solves a problem with python projects based on recent versions of setuptools.
These require a `pyproject.toml` file which can be checked by yapf, but only if the `toml` package is installed