### PR TITLE
feat: cd to workspace folder before executing yapf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,9 @@ jobs:
 
 You can pass any other [YAPF parameter](https://github.com/google/yapf#usage) using the `args` setting, e.g. for setting a different code style (default is PEP8), but you can also remove the `with` section entirely if you wish.
 
-If you want to exclude a certain directory, you can use the args field like this: `args: --verbose --exclude '**/tests/**'`. Thank you [@pksol](https://github.com/pksol) for the [example](https://github.com/AlexanderMelde/yapf-action/issues/1).
+If you want to exclude a certain file or directory, you can either use the `--exclude` parameter or a `.yapfignore` file.
+
+### Migration Notice
+Earlier versions of this action did not set the working directory before executing `yapf`.
+
+If you used the `--exclude '**/tests/**'` workaround, you might need to simplify this to `--exclude 'tests/**'` now.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,4 @@
 set -e
 echo "Checking formatting for $GITHUB_REPOSITORY"
 cd "$GITHUB_WORKSPACE"
-echo "Now running in:"
-pwd
-ls
 sh -c "yapf --diff --recursive . $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 set -e
 echo "Checking formatting for $GITHUB_REPOSITORY"
-sh -c "yapf --diff --recursive $GITHUB_WORKSPACE $*"
+cd "$GITHUB_WORKSPACE"
+echo "Now running in:"
+pwd
+ls
+sh -c "yapf --diff --recursive . $*"


### PR DESCRIPTION
This is necessary to have yapf honor `.yapfignore` or `pyproject.toml` files, which it reads from the directory that it is executed in. With the change, the call to `yapf` also passes `.` as the target for formatting; otherwise, relative paths specified in the ignore patterns do not match against the absolute target path.

This resolves #7.